### PR TITLE
Add backup database URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This project allow you to restore the last Scalingo PostgreSQL backup in an anot
 The app need to have a PostgreSQL addon and 2 env variables set:
 - `SCALINGO_CLI_TOKEN` that you can create here https://dashboard.scalingo.com/account/tokens
 - `SOURCE_APP` the name of the app where the backup will be fetched
+- `DATABASE_BACKUP_URL` the backup database URL
 
 You also need to follow this documentation since our app won't have any web container (any container at all actually).
 https://doc.scalingo.com/platform/app/web-less-app (spoiler `scalingo --app my-app scale web:0:M`)

--- a/replicate.sh
+++ b/replicate.sh
@@ -15,6 +15,12 @@ then
   exit 1
 fi
 
+if [ -z "$DATABASE_BACKUP_URL" ]
+then
+  echo "DATABASE_BACKUP_URL is not set"
+  exit 1
+fi
+
 install-scalingo-cli
 dbclient-fetcher psql
 
@@ -30,4 +36,4 @@ BACKUP_NAME=`tar -tf $ARCHIVE_NAME | tail -n 1`
 
 tar -C /app -xvf $ARCHIVE_NAME
 
-pg_restore --clean --if-exists --no-owner --no-privileges --no-comments --dbname $DATABASE_URL /app$BACKUP_NAME
+pg_restore --clean --if-exists --no-owner --no-privileges --no-comments --dbname $DATABASE_BACKUP_URL /app$BACKUP_NAME


### PR DESCRIPTION
Hello,

At Yespark, we are in the process of migrating from Heroku to Scalingo, and we need a replica database for our BI.

I've used your script, but it seems that the backup database URL is missing.

So, I've made this modification.